### PR TITLE
Update rbac.yaml

### DIFF
--- a/charts/alloy-operator/templates/rbac.yaml
+++ b/charts/alloy-operator/templates/rbac.yaml
@@ -151,6 +151,13 @@ rules:
       - horizontalpodautoscalers
     verbs:
       - '*'
+  # Rules which allow the management of Vertical Pod Autoscalers.
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - '*'
   # Rules which allow for the management of Prometheus Operator objects.
   - apiGroups:
       - monitoring.coreos.com


### PR DESCRIPTION
fix: allow operator to manage vertical pod autscaling resource when used alloy-singleton collector